### PR TITLE
Add some utility functions for Go programming.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -26,7 +26,7 @@ SRCS=	autoexec.c basic.c bell.c buffer.c cinfo.c dir.c display.c \
 	echo.c extend.c file.c fileio.c help.c kbd.c keymap.c \
 	line.c macro.c main.c match.c modes.c paragraph.c random.c \
 	re_search.c region.c search.c spawn.c tty.c ttyio.c ttykbd.c \
-	undo.c version.c window.c word.c yank.c funmap.c 
+	undo.c version.c window.c word.c yank.c funmap.c gofuncs.c
 
 # ported from OpenBSD's libutil
 SRCS+=	fparseln.c

--- a/def.h
+++ b/def.h
@@ -693,8 +693,14 @@ int		 togglevisiblebell(int, int);
 void		 dobeep(void);
 
 /* gofuncs.c */
-int		 goimports(int, int);
 int		 gobuild(int, int);
+int		 gobuildall(int, int);
+int		 goimports(int, int);
+int		 gotest(int, int);
+int		 gotestcover(int, int);
+int		 gotestall(int, int);
+int		 goinstall(int, int);
+int		 goinstallall(int, int);
 
 /*
  * Externals.

--- a/def.h
+++ b/def.h
@@ -1,3 +1,4 @@
+
 /*	$OpenBSD: def.h,v 1.141 2014/04/03 20:17:12 lum Exp $	*/
 
 /* This file is in the public domain. */
@@ -597,6 +598,7 @@ void		 region_put_data(const char *, int);
 int		 markbuffer(int, int);
 int		 piperegion(int, int);
 int		 shellcommand(int, int);
+int		 shellcmdoutput(char * const[], char * const, int, int);
 int		 pipeio(const char * const, char * const[], char * const, int,
 		     struct buffer *);
 
@@ -692,6 +694,7 @@ void		 dobeep(void);
 
 /* gofuncs.c */
 int		 goimports(int, int);
+int		 gobuild(int, int);
 
 /*
  * Externals.

--- a/def.h
+++ b/def.h
@@ -690,6 +690,9 @@ int		 toggleaudiblebell(int, int);
 int		 togglevisiblebell(int, int);
 void		 dobeep(void);
 
+/* gofuncs.c */
+int		 goimports(int, int);
+
 /*
  * Externals.
  */

--- a/funmap.c
+++ b/funmap.c
@@ -206,6 +206,7 @@ static struct funmap functnames[] = {
 	{showcpos, "what-cursor-position",},
 	{filewrite, "write-file",},
 	{yank, "yank",},
+	{goimports, "goimports",},
 	{NULL, NULL,}
 };
 

--- a/funmap.c
+++ b/funmap.c
@@ -207,6 +207,7 @@ static struct funmap functnames[] = {
 	{filewrite, "write-file",},
 	{yank, "yank",},
 	{goimports, "goimports",},
+	{gobuild, "gobuild",},
 	{NULL, NULL,}
 };
 

--- a/funmap.c
+++ b/funmap.c
@@ -206,8 +206,14 @@ static struct funmap functnames[] = {
 	{showcpos, "what-cursor-position",},
 	{filewrite, "write-file",},
 	{yank, "yank",},
+	{gobuild, "go-build",},
+	{gobuildall, "go-build-all",},
 	{goimports, "goimports",},
-	{gobuild, "gobuild",},
+	{gotest, "go-test",},
+	{gotestcover, "go-test-cover",},
+	{gotestall, "go-test-all",},
+	{goinstall, "go-install",},
+	{goinstallall, "go-install-all",},
 	{NULL, NULL,}
 };
 

--- a/gofuncs.c
+++ b/gofuncs.c
@@ -58,9 +58,6 @@ goimports(int f, int n)
 	return rv;
 }
 
-/*
- * gobuild attempts to build the package in the current directory.
- */
 int
 gobuild(int f, int n)
 {
@@ -75,6 +72,7 @@ gobuild(int f, int n)
 		return (FALSE);
 	}
 
+	ewprintf("Building package...");
 	rv = callgocommand("go build");
 	if (-1 == chdir(wd)) {
 		ewprintf("Failed to change directory.");
@@ -82,3 +80,119 @@ gobuild(int f, int n)
 	}
 	return rv;
 }
+
+int
+gobuildall(int f, int n)
+{
+	char	  wd[NFILEN+1];
+	int	  rv = FALSE;
+
+	if (NULL == getcwd(wd, NFILEN)) {
+		ewprintf("Working directory is too long.");
+		return (FALSE);
+	} else if (-1 == chdir(curbp->b_cwd)) {
+		ewprintf("Failed to change directory.");
+		return (FALSE);
+	}
+
+	ewprintf("Building all subpackages...");
+	rv = callgocommand("go build ./...");
+	if (-1 == chdir(wd)) {
+		ewprintf("Failed to change directory.");
+		return (FALSE);
+	}
+	return rv;
+}
+
+int
+gotestcover(int f, int n)
+{
+	char	  wd[NFILEN+1];
+	int	  rv = FALSE;
+
+	if (NULL == getcwd(wd, NFILEN)) {
+		ewprintf("Working directory is too long.");
+		return (FALSE);
+	} else if (-1 == chdir(curbp->b_cwd)) {
+		ewprintf("Failed to change directory.");
+		return (FALSE);
+	}
+
+	ewprintf("Testing with code coverage...");
+	rv = callgocommand("go test -cover");
+	if (-1 == chdir(wd)) {
+		ewprintf("Failed to change directory.");
+		return (FALSE);
+	}
+	return rv;
+}
+
+int
+gotest(int f, int n)
+{
+	char	  wd[NFILEN+1];
+	int	  rv = FALSE;
+
+	if (NULL == getcwd(wd, NFILEN)) {
+		ewprintf("Working directory is too long.");
+		return (FALSE);
+	} else if (-1 == chdir(curbp->b_cwd)) {
+		ewprintf("Failed to change directory.");
+		return (FALSE);
+	}
+
+	ewprintf("Testing current package...");
+	rv = callgocommand("go test");
+	if (-1 == chdir(wd)) {
+		ewprintf("Failed to change directory.");
+		return (FALSE);
+	}
+	return rv;
+}
+
+int
+goinstall(int f, int n)
+{
+	char	  wd[NFILEN+1];
+	int	  rv = FALSE;
+
+	if (NULL == getcwd(wd, NFILEN)) {
+		ewprintf("Working directory is too long.");
+		return (FALSE);
+	} else if (-1 == chdir(curbp->b_cwd)) {
+		ewprintf("Failed to change directory.");
+		return (FALSE);
+	}
+
+	ewprintf("Installing current package...");
+	rv = callgocommand("go install ./...");
+	if (-1 == chdir(wd)) {
+		ewprintf("Failed to change directory.");
+		return (FALSE);
+	}
+	return rv;
+}
+
+int
+goinstallall(int f, int n)
+{
+	char	  wd[NFILEN+1];
+	int	  rv = FALSE;
+
+	if (NULL == getcwd(wd, NFILEN)) {
+		ewprintf("Working directory is too long.");
+		return (FALSE);
+	} else if (-1 == chdir(curbp->b_cwd)) {
+		ewprintf("Failed to change directory.");
+		return (FALSE);
+	}
+
+	ewprintf("Installing all subpackages...");
+	rv = callgocommand("go install ./...");
+	if (-1 == chdir(wd)) {
+		ewprintf("Failed to change directory.");
+		return (FALSE);
+	}
+	return rv;
+}
+

--- a/gofuncs.c
+++ b/gofuncs.c
@@ -6,30 +6,79 @@
 
 #include <sys/types.h>
 
+#include <stdlib.h>
+#include <unistd.h>
 #include "def.h"
+
+int
+callgocommand(char *prog)
+{
+	char	*cmd[] = {"sh", "-c", NULL, NULL};
+
+	cmd[2] = prog;
+	if (FALSE == shellcmdoutput(cmd, NULL, 0, 1)) {
+		return(FALSE);
+	}
+
+	if ((curbp->b_flag & (BFCHG | BFDIRTY)) == 0) {
+		if (fchecktime(curbp) != TRUE) {
+			curbp->b_flag |= BFDIRTY;
+		}
+	}
+
+	if ((curbp->b_flag & (BFDIRTY | BFIGNDIRTY)) == BFDIRTY) {
+		if ((FALSE) == dorevert()) {
+			return (FALSE);
+		}
+		redraw(0, 0);
+		eerase();
+		ewprintf("%s updated.", curbp->b_fname);
+	}
+	return (TRUE);
+}
 
 int
 goimports(int f, int n)
 {
+	int	 rv = FALSE;
 	char	*cmd = NULL;
+	char	*gopath = NULL;
 
-	if (f & FFARG) {
-		/* not implemented yet */
-	}
-
-	if (-1 == asprintf(&cmd, "goimports -l -w %s", curbp->b_fname)) {
-		return (FALSE);
-	}
-	
-	if (-1 == system(cmd)) {
+	if (NULL == (gopath = getenv("GOPATH"))) {
+		ewprintf("GOPATH not set.");
 		return (FALSE);
 	}
 
-	if ((TRUE) == checkdirty(curbp)) {
-		if ((FALSE) == revertbuffer(FFARG,0)) {
-			return (FALSE);
-		}
+	if (-1 == asprintf(&cmd, "%s/bin/goimports -l -w %s", gopath, curbp->b_fname)) {
+		return (FALSE);
 	}
 
-	return redraw(0, 0);
+	rv = callgocommand(cmd);
+	free(cmd);
+	return rv;
+}
+
+/*
+ * gobuild attempts to build the package in the current directory.
+ */
+int
+gobuild(int f, int n)
+{
+	char	  wd[NFILEN+1];
+	int	  rv = FALSE;
+
+	if (NULL == getcwd(wd, NFILEN)) {
+		ewprintf("Working directory is too long.");
+		return (FALSE);
+	} else if (-1 == chdir(curbp->b_cwd)) {
+		ewprintf("Failed to change directory.");
+		return (FALSE);
+	}
+
+	rv = callgocommand("go build");
+	if (-1 == chdir(wd)) {
+		ewprintf("Failed to change directory.");
+		return (FALSE);
+	}
+	return rv;
 }

--- a/gofuncs.c
+++ b/gofuncs.c
@@ -1,0 +1,35 @@
+/*
+ * This file is in the public domain.
+ *
+ * Author: Kyle Isom <kyle@tyrfingr.is>
+ */
+
+#include <sys/types.h>
+
+#include "def.h"
+
+int
+goimports(int f, int n)
+{
+	char	*cmd = NULL;
+
+	if (f & FFARG) {
+		/* not implemented yet */
+	}
+
+	if (-1 == asprintf(&cmd, "goimports -l -w %s", curbp->b_fname)) {
+		return (FALSE);
+	}
+	
+	if (-1 == system(cmd)) {
+		return (FALSE);
+	}
+
+	if ((TRUE) == checkdirty(curbp)) {
+		if ((FALSE) == revertbuffer(FFARG,0)) {
+			return (FALSE);
+		}
+	}
+
+	return redraw(0, 0);
+}

--- a/keymap.c
+++ b/keymap.c
@@ -60,6 +60,27 @@ static PF cCsc[] = {
 	csfindtext		/* t */
 };
 
+static PF cCgc[] = {
+	gobuild,		/* b */
+	rescan,			/* c */
+	rescan,			/* d */
+	rescan,			/* e */
+	rescan,			/* f */
+	rescan,			/* g */
+	rescan,			/* h */
+	rescan,			/* i */
+	rescan,			/* j */
+	rescan,			/* k */
+	rescan,			/* l */
+	rescan,			/* m */
+	rescan,			/* n */
+	rescan,			/* o */
+	rescan,			/* p */
+	rescan,			/* q */
+	rescan,			/* r */
+	goimports		/* s */
+};
+
 static struct KEYMAPE (1 + IMAPEXT) cCsmap = {
 	1,
 	1 + IMAPEXT,
@@ -71,17 +92,35 @@ static struct KEYMAPE (1 + IMAPEXT) cCsmap = {
 	}
 };
 
+static struct KEYMAPE (1 + IMAPEXT) cCgmap = {
+	1,
+	1 + IMAPEXT,
+	rescan,
+	{
+		{
+			'b', 's', cCgc, NULL
+		}
+	}
+};
+
 static PF cCs[] = {
 	NULL			/* s */
 };
 
-struct KEYMAPE (2 + IMAPEXT) ccmap = {
-	2,
-	2 + IMAPEXT,
+static PF cCg[] = {
+	NULL			/* g */
+};
+
+struct KEYMAPE (3 + IMAPEXT) ccmap = {
+	3,
+	3 + IMAPEXT,
 	rescan,
 	{
 		{
 			CCHR('@'), CCHR('@'), (PF[]){ rescan }, NULL
+		},
+		{
+			'g', 'g', cCg, (KEYMAP *) & cCgmap
 		},
 		{
 			's', 's', cCs, (KEYMAP *) & cCsmap

--- a/keymap.c
+++ b/keymap.c
@@ -61,14 +61,15 @@ static PF cCsc[] = {
 };
 
 static PF cCgc[] = {
+	gobuildall,		/* a */
 	gobuild,		/* b */
-	rescan,			/* c */
+	gotestcover,		/* c */
 	rescan,			/* d */
-	rescan,			/* e */
+	goinstallall,		/* e */
 	rescan,			/* f */
 	rescan,			/* g */
 	rescan,			/* h */
-	rescan,			/* i */
+	goinstall,		/* i */
 	rescan,			/* j */
 	rescan,			/* k */
 	rescan,			/* l */
@@ -77,8 +78,9 @@ static PF cCgc[] = {
 	rescan,			/* o */
 	rescan,			/* p */
 	rescan,			/* q */
-	rescan,			/* r */
-	goimports		/* s */
+	gotestall,		/* r */
+	goimports,		/* s */
+	gotest			/* t */
 };
 
 static struct KEYMAPE (1 + IMAPEXT) cCsmap = {
@@ -98,7 +100,7 @@ static struct KEYMAPE (1 + IMAPEXT) cCgmap = {
 	rescan,
 	{
 		{
-			'b', 's', cCgc, NULL
+			'a', 't', cCgc, NULL
 		}
 	}
 };

--- a/kmg.1
+++ b/kmg.1
@@ -126,6 +126,22 @@ set-mark-command
 beginning-of-line
 .It C-b
 backward-char
+.It C-c g a
+go-build-all
+.It C-c g b
+go-build
+.It C-c g c
+go-test-cover
+.It C-c g e
+go-install-all
+.It C-c g i
+go-install
+.It C-c g r
+go-test-all
+.It C-c g s
+goimports
+.It C-c g t
+go-test
 .It C-c s c
 cscope-find-functions-calling-this-function
 .It C-c s d

--- a/region.c
+++ b/region.c
@@ -28,7 +28,6 @@ static	int	iomux(int, char * const, int, struct buffer *);
 static	int	preadin(int, struct buffer *);
 static	void	pwriteout(int, char **, int *);
 static	int	setsize(struct region *, RSIZE);
-static	int	shellcmdoutput(char * const[], char * const, int);
 
 /*
  * Kill the region.  Ask "getregion" to figure out the bounds of the region.
@@ -446,7 +445,7 @@ piperegion(int f, int n)
 
 	region_get_data(&region, text, len);
 
-	return shellcmdoutput(argv, text, len);
+	return shellcmdoutput(argv, text, len, 0);
 }
 
 /*
@@ -469,12 +468,12 @@ shellcommand(int f, int n)
 
 	argv[2] = cmd;
 
-	return shellcmdoutput(argv, NULL, 0);
+	return shellcmdoutput(argv, NULL, 0, 0);
 }
 
 
 int
-shellcmdoutput(char* const argv[], char* const text, int len)
+shellcmdoutput(char* const argv[], char* const text, int len, int noout)
 {
 
 	struct buffer *bp;
@@ -494,10 +493,15 @@ shellcmdoutput(char* const argv[], char* const text, int len)
 
 	if (ret == TRUE) {
 		eerase();
-		if (lforw(bp->b_headp) == bp->b_headp)
-			addline(bp, "(Shell command succeeded with no output)");
+		if (lforw(bp->b_headp) == bp->b_headp) {
+			if (!noout) {
+				addline(bp, "(Shell command succeeded with no output)");
+			} else {
+				killbuffer(bp);
+				onlywind(0, 0);
+			}
+		}
 	}
-
 	free(text);
 	return (ret);
 }


### PR DESCRIPTION
This adds the C-c g map and associated functions.
- go-build
- go-build-all (C-c g a)
- goimports (C-c g s)
- go-test (C-c g t)
- go-test-cover (C-c g c)
- go-test-all (C-c g r)
- go-install (C-c g i)
- go-install-all (C-c g e)
